### PR TITLE
实现在mysql读取渠道账号配置的功能，并且不干扰短信的本地配置（渠道账号以及流量负载的动态配置）新增支付宝小程序消息推送

### DIFF
--- a/austin-common/src/main/java/com/java3y/austin/common/constant/SendAccountConstant.java
+++ b/austin-common/src/main/java/com/java3y/austin/common/constant/SendAccountConstant.java
@@ -79,6 +79,12 @@ public class SendAccountConstant {
     public static final String WECHAT_MINI_PROGRAM_PREFIX = "mini_program_";
 
     /**
+     * 微信小程序 应用消息 账号
+     */
+    public static final String ALIPAY_MINI_PROGRAM_ACCOUNT_KEY = "alipayMiniProgramAccount";
+    public static final String ALIPAY_MINI_PROGRAM_PREFIX = "alipay_mini_program_";
+
+    /**
      * 短信 账号
      */
     public static final String SMS_ACCOUNT_KEY = "smsAccount";

--- a/austin-common/src/main/java/com/java3y/austin/common/dto/account/AlipayMiniProgramAccount.java
+++ b/austin-common/src/main/java/com/java3y/austin/common/dto/account/AlipayMiniProgramAccount.java
@@ -1,0 +1,42 @@
+package com.java3y.austin.common.dto.account;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * @author jwq
+ * 支付宝小程序订阅消息账号配置
+ */
+@Data
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class AlipayMiniProgramAccount {
+
+    /**
+     * 应用私钥
+     */
+    private String privateKey;
+
+    /**
+     * 支付宝公钥
+     */
+    private String alipayPublicKey;
+
+    /**
+     * 支付宝小程序的AppID
+     */
+    private String appId;
+
+    /**
+     * 订阅模版Id
+     */
+    private String userTemplateId;
+
+    /**
+     * 点击跳转到的小程序页面
+     */
+    private String page;
+}

--- a/austin-common/src/main/java/com/java3y/austin/common/dto/model/AlipayMiniProgramContentModel.java
+++ b/austin-common/src/main/java/com/java3y/austin/common/dto/model/AlipayMiniProgramContentModel.java
@@ -1,0 +1,25 @@
+package com.java3y.austin.common.dto.model;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.Map;
+
+/**
+ * @author jwq
+ * 支付宝小程序订阅消息内容
+ */
+@Data
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class AlipayMiniProgramContentModel extends ContentModel{
+
+    /**
+     * 模板消息发送的数据
+     */
+    Map<String, String> map;
+
+}

--- a/austin-common/src/main/java/com/java3y/austin/common/enums/ChannelType.java
+++ b/austin-common/src/main/java/com/java3y/austin/common/enums/ChannelType.java
@@ -28,6 +28,7 @@ public enum ChannelType {
     DING_DING_WORK_NOTICE(90, "dingDingWorkNotice(钉钉工作通知)", DingDingWorkContentModel.class, "ding_ding_work_notice"),
     ENTERPRISE_WE_CHAT_ROBOT(100, "enterpriseWeChat(企业微信机器人)", EnterpriseWeChatRobotContentModel.class, "enterprise_we_chat_robot"),
     FEI_SHU_ROBOT(110, "feiShuRoot(飞书机器人)", FeiShuRobotContentModel.class, "fei_shu_robot"),
+    ALIPAY_MINI_PROGRAM(120,"alipayMiniProgram(支付宝小程序)",AlipayMiniProgramContentModel.class,"alipay_mini_program"),
     ;
 
     /**

--- a/austin-handler/pom.xml
+++ b/austin-handler/pom.xml
@@ -57,6 +57,11 @@
             <groupId>com.github.binarywang</groupId>
             <artifactId>weixin-java-cp</artifactId>
         </dependency>
+        <!--支付宝SDK-->
+        <dependency>
+            <groupId>com.alipay.sdk</groupId>
+            <artifactId>alipay-sdk-java</artifactId>
+        </dependency>
 
     </dependencies>
 </project>

--- a/austin-handler/src/main/java/com/java3y/austin/handler/alipay/AlipayMiniProgramAccountService.java
+++ b/austin-handler/src/main/java/com/java3y/austin/handler/alipay/AlipayMiniProgramAccountService.java
@@ -1,0 +1,18 @@
+package com.java3y.austin.handler.alipay;
+
+import com.alipay.api.AlipayApiException;
+import com.java3y.austin.handler.domain.alipay.AlipayMiniProgramParam;
+
+/**
+ * @author jwq
+ * 支付宝小程序发送订阅消息接口
+ */
+public interface AlipayMiniProgramAccountService {
+    /**
+     * 发送订阅消息
+     *
+     * @param miniProgramParam 订阅消息参数
+     * @throws AlipayApiException alipay异常
+     */
+    void send(AlipayMiniProgramParam miniProgramParam) throws AlipayApiException;
+}

--- a/austin-handler/src/main/java/com/java3y/austin/handler/alipay/impl/AlipayMiniProgramAccountServiceImpl.java
+++ b/austin-handler/src/main/java/com/java3y/austin/handler/alipay/impl/AlipayMiniProgramAccountServiceImpl.java
@@ -1,0 +1,89 @@
+package com.java3y.austin.handler.alipay.impl;
+
+import com.alipay.api.AlipayApiException;
+import com.alipay.api.AlipayClient;
+import com.alipay.api.AlipayConfig;
+import com.alipay.api.DefaultAlipayClient;
+import com.alipay.api.domain.AlipayOpenAppMiniTemplatemessageSendModel;
+import com.alipay.api.request.AlipayOpenAppMiniTemplatemessageSendRequest;
+import com.java3y.austin.common.constant.SendAccountConstant;
+import com.java3y.austin.common.dto.account.AlipayMiniProgramAccount;
+import com.java3y.austin.handler.alipay.AlipayMiniProgramAccountService;
+import com.java3y.austin.handler.domain.alipay.AlipayMiniProgramParam;
+import com.java3y.austin.support.utils.AccountUtils;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * @author jwq
+ * 支付宝小程序发送订阅消息实现
+ */
+@Service
+@Slf4j
+public class AlipayMiniProgramAccountServiceImpl implements AlipayMiniProgramAccountService {
+
+    @Autowired
+    private AccountUtils accountUtils;
+
+    /**
+     * 发送订阅消息
+     *
+     * @param miniProgramParam 订阅消息参数
+     * @throws AlipayApiException alipay异常
+     */
+    @Override
+    public void send(AlipayMiniProgramParam miniProgramParam) throws AlipayApiException {
+        AlipayMiniProgramAccount miniProgramAccount = accountUtils.getAccount(miniProgramParam.getSendAccount(),
+                SendAccountConstant.ALIPAY_MINI_PROGRAM_ACCOUNT_KEY,
+                SendAccountConstant.ALIPAY_MINI_PROGRAM_PREFIX,
+                AlipayMiniProgramAccount.class);
+
+        AlipayClient client = initService(miniProgramAccount);
+        List<AlipayOpenAppMiniTemplatemessageSendRequest> request = assembleReq(miniProgramParam, miniProgramAccount);
+        for(AlipayOpenAppMiniTemplatemessageSendRequest req : request){
+            client.execute(req);
+        }
+    }
+
+    /**
+     * 组装模板消息的参数
+     */
+    private List<AlipayOpenAppMiniTemplatemessageSendRequest> assembleReq(AlipayMiniProgramParam alipayMiniProgramParam, AlipayMiniProgramAccount alipayMiniProgramAccount){
+        Set<String> receiver = alipayMiniProgramParam.getToUserId();
+        List<AlipayOpenAppMiniTemplatemessageSendRequest> requestList = new ArrayList<>(receiver.size());
+
+        for(String toUserId : receiver){
+            AlipayOpenAppMiniTemplatemessageSendRequest request = new AlipayOpenAppMiniTemplatemessageSendRequest();
+            AlipayOpenAppMiniTemplatemessageSendModel model = new AlipayOpenAppMiniTemplatemessageSendModel();
+            model.setToUserId(toUserId);
+            model.setUserTemplateId(alipayMiniProgramAccount.getUserTemplateId());
+            model.setPage(alipayMiniProgramAccount.getPage());
+            model.setData(alipayMiniProgramParam.getData().toString());
+            request.setBizModel(model);
+            requestList.add(request);
+        }
+        return requestList;
+    }
+
+    /**
+     * 初始化支付宝小程序
+     */
+    private AlipayClient initService(AlipayMiniProgramAccount alipayMiniProgramAccount) throws AlipayApiException {
+        AlipayConfig alipayConfig = new AlipayConfig();
+        alipayConfig.setServerUrl("https://openapi.alipaydev.com/gateway.do");
+        alipayConfig.setAppId(alipayMiniProgramAccount.getAppId());
+        alipayConfig.setPrivateKey(alipayMiniProgramAccount.getPrivateKey());
+        alipayConfig.setFormat("json");
+        alipayConfig.setAlipayPublicKey(alipayMiniProgramAccount.getAlipayPublicKey());
+        alipayConfig.setCharset("utf-8");
+        alipayConfig.setSignType("RSA2");
+        return new DefaultAlipayClient(alipayConfig);
+    }
+
+
+}

--- a/austin-handler/src/main/java/com/java3y/austin/handler/domain/alipay/AlipayMiniProgramParam.java
+++ b/austin-handler/src/main/java/com/java3y/austin/handler/domain/alipay/AlipayMiniProgramParam.java
@@ -1,0 +1,43 @@
+package com.java3y.austin.handler.domain.alipay;
+
+import lombok.Builder;
+import lombok.Data;
+
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * @author jwq
+ * 支付宝小程序参数
+ */
+@Data
+@Builder
+public class AlipayMiniProgramParam {
+    /**
+     * 业务Id
+     */
+    private Long messageTemplateId;
+
+    /**
+     * 发送账号
+     */
+    private Integer sendAccount;
+
+    /**
+     * 接收者（用户）的 UserId
+     */
+    private Set<String> toUserId;
+
+    /**
+     * 模板内容，格式形如 { "key1": { "value": any }, "key2": { "value": any } }
+     */
+    private Map<String, String> data;
+
+//    /**
+//     * 支付消息模板：需传入用户发生的交易行为的支付宝交易号 trade_no；
+//     * 表单提交模板：需传入用户在小程序触发表单提交事件获得的表单号；
+//     * 刷脸消息模板：需传入在IOT刷脸后得到的ftoken等，用于信息发送的校验。
+//     * 说明：订阅消息模板无需传入本参数。
+//     */
+//    private String formId;
+}

--- a/austin-handler/src/main/java/com/java3y/austin/handler/handler/impl/AlipayMiniProgramAccountHandler.java
+++ b/austin-handler/src/main/java/com/java3y/austin/handler/handler/impl/AlipayMiniProgramAccountHandler.java
@@ -1,0 +1,67 @@
+package com.java3y.austin.handler.handler.impl;
+
+import com.alibaba.fastjson.JSON;
+import com.google.common.base.Throwables;
+import com.java3y.austin.common.domain.TaskInfo;
+import com.java3y.austin.common.dto.model.AlipayMiniProgramContentModel;
+import com.java3y.austin.common.enums.ChannelType;
+import com.java3y.austin.handler.alipay.AlipayMiniProgramAccountService;
+import com.java3y.austin.handler.domain.alipay.AlipayMiniProgramParam;
+import com.java3y.austin.handler.handler.BaseHandler;
+import com.java3y.austin.handler.handler.Handler;
+import com.java3y.austin.support.domain.MessageTemplate;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+/**
+ * @author jwq
+ * 支付宝小程序发送订阅消息
+ */
+@Component
+@Slf4j
+public class AlipayMiniProgramAccountHandler extends BaseHandler implements Handler {
+
+    @Autowired
+    private AlipayMiniProgramAccountService alipayMiniProgramAccountService;
+
+    public AlipayMiniProgramAccountHandler() {
+        channelCode = ChannelType.ALIPAY_MINI_PROGRAM.getCode();
+    }
+
+    @Override
+    public boolean handler(TaskInfo taskInfo) {
+        AlipayMiniProgramParam miniProgramParam = buildMiniProgramParam(taskInfo);
+        try {
+            alipayMiniProgramAccountService.send(miniProgramParam);
+        }catch (Exception e) {
+            log.error("AlipayMiniProgramAccountHandler#handler fail:{},params:{}",
+                    Throwables.getStackTraceAsString(e), JSON.toJSONString(taskInfo));
+            return false;
+        }
+        return true;
+    }
+
+    /**
+     * 通过taskInfo构建小程序订阅消息
+     *
+     * @param taskInfo 任务信息
+     * @return AlipayMiniProgramParam
+     */
+    private AlipayMiniProgramParam buildMiniProgramParam(TaskInfo taskInfo){
+        AlipayMiniProgramParam param = AlipayMiniProgramParam.builder()
+                .toUserId(taskInfo.getReceiver())
+                .messageTemplateId(taskInfo.getMessageTemplateId())
+                .sendAccount(taskInfo.getSendAccount())
+                .build();
+
+        AlipayMiniProgramContentModel contentModel = (AlipayMiniProgramContentModel) taskInfo.getContentModel();
+        param.setData(contentModel.getMap());
+        return param;
+    }
+
+    @Override
+    public void recall(MessageTemplate messageTemplate) {
+
+    }
+}

--- a/austin-handler/src/main/java/com/java3y/austin/handler/receipt/TencentSmsReceipt.java
+++ b/austin-handler/src/main/java/com/java3y/austin/handler/receipt/TencentSmsReceipt.java
@@ -50,7 +50,7 @@ public class TencentSmsReceipt {
     public void pull() {
 
         // 获取腾讯云账号信息
-        TencentSmsAccount account = accountUtils.getAccount(10, SendAccountConstant.SMS_ACCOUNT_KEY, SendAccountConstant.SMS_PREFIX, TencentSmsAccount.class);
+        TencentSmsAccount account = accountUtils.getSmsAccount(10, SendAccountConstant.SMS_ACCOUNT_KEY, SendAccountConstant.SMS_PREFIX, TencentSmsAccount.class);
         try {
             SmsClient client = getSmsClient(account);
 

--- a/austin-handler/src/main/java/com/java3y/austin/handler/script/impl/TencentSmsScript.java
+++ b/austin-handler/src/main/java/com/java3y/austin/handler/script/impl/TencentSmsScript.java
@@ -49,7 +49,7 @@ public class TencentSmsScript extends BaseSmsScript implements SmsScript {
     @Override
     public List<SmsRecord> send(SmsParam smsParam) {
         try {
-            TencentSmsAccount tencentSmsAccount = accountUtils.getAccount(SendAccountConstant.TENCENT_SMS_CODE, SendAccountConstant.SMS_ACCOUNT_KEY, SendAccountConstant.SMS_PREFIX, TencentSmsAccount.class);
+            TencentSmsAccount tencentSmsAccount = accountUtils.getSmsAccount(SendAccountConstant.TENCENT_SMS_CODE, SendAccountConstant.SMS_ACCOUNT_KEY, SendAccountConstant.SMS_PREFIX, TencentSmsAccount.class);
             SmsClient client = init(tencentSmsAccount);
             SendSmsRequest request = assembleReq(smsParam, tencentSmsAccount);
             SendSmsResponse response = client.SendSms(request);

--- a/austin-handler/src/main/java/com/java3y/austin/handler/script/impl/YunPianSmsScript.java
+++ b/austin-handler/src/main/java/com/java3y/austin/handler/script/impl/YunPianSmsScript.java
@@ -39,7 +39,7 @@ public class YunPianSmsScript extends BaseSmsScript implements SmsScript {
     public List<SmsRecord> send(SmsParam smsParam) {
 
         try {
-            YunPianSmsAccount account = accountUtils.getAccount(SendAccountConstant.YUN_PIAN_SMS_CODE, SendAccountConstant.SMS_ACCOUNT_KEY, SendAccountConstant.SMS_PREFIX, YunPianSmsAccount.class);
+            YunPianSmsAccount account = accountUtils.getSmsAccount(SendAccountConstant.YUN_PIAN_SMS_CODE, SendAccountConstant.SMS_ACCOUNT_KEY, SendAccountConstant.SMS_PREFIX, YunPianSmsAccount.class);
             Map<String, Object> params = assembleParam(smsParam, account);
 
             String result = HttpRequest.post(account.getUrl())

--- a/austin-support/src/main/java/com/java3y/austin/support/service/ConfigService.java
+++ b/austin-support/src/main/java/com/java3y/austin/support/service/ConfigService.java
@@ -18,4 +18,14 @@ public interface ConfigService {
      */
     String getProperty(String key, String defaultValue);
 
+    /**
+     * 读取配置
+     * 1、当启动使用了mysql，apollo或者nacos，优先读取远程配置
+     * 2、当没有启动远程配置，读取本地 local.properties 配置文件的内容
+     * @param sendAccount
+     * @param key
+     * @param defaultValue
+     * @return
+     */
+    String getProperty(Integer sendAccount, String key, String defaultValue);
 }

--- a/austin-support/src/main/java/com/java3y/austin/support/service/impl/ConfigServiceImpl.java
+++ b/austin-support/src/main/java/com/java3y/austin/support/service/impl/ConfigServiceImpl.java
@@ -10,6 +10,7 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 
 import java.nio.charset.StandardCharsets;
+import java.sql.*;
 
 
 /**
@@ -40,7 +41,69 @@ public class ConfigServiceImpl implements ConfigService {
     @Autowired
     private NacosUtils nacosUtils;
 
+    /**
+     * Mysql配置
+     */
+    @Value("${austin.mysql.enable}")
+    private Boolean enableMysql;
+    @Value("${spring.datasource.url}")
+    private String url;
+    @Value("${austin.database.username}")
+    private String user;
+    @Value("${austin.database.password}")
+    private String pass;
+    @Value("${spring.datasource.driver-class-name}")
+    private String className;
 
+    public String getPropertyById(Integer sendAccount) {
+        Connection conn = null;
+        Statement stmt = null;
+        String accountConfig = null;
+        try {
+            Class.forName(className);
+            conn = DriverManager.getConnection(url, user, pass);
+            stmt = conn.createStatement();
+            int Cid = sendAccount - 1;
+            String sql = "SELECT id, name, send_channel, account_config FROM channel_account LIMIT "+Cid+",1";
+            ResultSet rs = stmt.executeQuery(sql);
+            while (rs.next()) {
+                accountConfig = rs.getString("account_config");
+//                System.out.println("选用账号的参数为: " + accountConfig);
+            }
+            rs.close();
+            stmt.close();
+            conn.close();
+        } catch (ClassNotFoundException | SQLException e) {
+            e.printStackTrace();
+        } finally {
+            try {
+                if (stmt != null) stmt.close();
+            } catch (SQLException se1) {
+                se1.printStackTrace();
+            }
+            try {
+                if (conn != null) conn.close();
+            } catch (SQLException se2) {
+                se2.printStackTrace();
+            }
+        }
+        return accountConfig;
+    }
+
+    @Override
+    public String getProperty(Integer sendAccount, String key, String defaultValue) {
+        if (enableApollo) {
+            Config config = com.ctrip.framework.apollo.ConfigService.getConfig(namespaces.split(StrUtil.COMMA)[0]);
+            return config.getProperty(key, defaultValue);
+        } else if (enableNacos) {
+            return nacosUtils.getProperty(key, defaultValue);
+        } else if (enableMysql) {
+            return getPropertyById(sendAccount);
+        } else {
+//            System.out.println(props.getProperty(key, defaultValue));
+            return props.getProperty(key, defaultValue);
+        }
+    }
     @Override
     public String getProperty(String key, String defaultValue) {
         if (enableApollo) {

--- a/austin-support/src/main/java/com/java3y/austin/support/utils/AccountUtils.java
+++ b/austin-support/src/main/java/com/java3y/austin/support/utils/AccountUtils.java
@@ -8,6 +8,7 @@ import com.ctrip.framework.apollo.spring.annotation.ApolloConfig;
 import com.java3y.austin.common.constant.AustinConstant;
 import com.java3y.austin.support.service.ConfigService;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
 /**
@@ -21,7 +22,11 @@ public class AccountUtils {
     @Autowired
     private ConfigService config;
 
+    @Value("${austin.mysql.enable}")
+    private Boolean enableMysql;
+
     /**
+     * local.properties配置格式
      * (key:smsAccount)短信参数示例：[{"sms_10":{"url":"sms.tencentcloudapi.com","region":"ap-guangzhou","secretId":"AKIDhDxxxxxxxx1WljQq","secretKey":"B4hwww39yxxxrrrrgxyi","smsSdkAppId":"1423123125","templateId":"1182097","signName":"Java3y公众号","supplierId":10,"supplierName":"腾讯云"}},{"sms_20":{"url":"https://sms.yunpian.com/v2/sms/tpl_batch_send.json","apikey":"caffff8234234231b5cd7","tpl_id":"523333332","supplierId":20,"supplierName":"云片"}}]
      * (key:emailAccount)邮件参数示例：[{"email_10":{"host":"smtp.qq.com","port":465,"user":"23423423@qq.com","pass":"23423432432423423","from":"234@qq.com","starttlsEnable":true,"auth":true,"sslEnable":true}},{"email_20":{"host":"smtp.163.com","port":465,"user":"22222@163.com","pass":"23432423","from":"234324324234@163.com","starttlsEnable":false,"auth":true,"sslEnable":true}}]
      * (key:enterpriseWechatAccount)企业微信参数示例：[{"enterprise_wechat_10":{"corpId":"wwf87603333e00069c","corpSecret":"-IFWxS2222QxzPIorNV11144D915DM","agentId":10044442,"token":"rXROB3333Kf6i","aesKey":"MKZtoFxHIM44444M7ieag3r9ZPUsl"}}]
@@ -30,7 +35,7 @@ public class AccountUtils {
      * (key:officialAccount) 微信服务号模板消息参数示例：[{"official_10":{"appId":"wxecb4693d2eef1ea7","secret":"624asdfsa1640d769ba20120821","templateId":"JHUk6eE9T5Ts7asdfsadfiKNDQsk-Q","url":"http://weixin.qq.com/download","miniProgramId":"xiaochengxuappid12345","path":"index?foo=bar"}}]
      * (key:miniProgramAccount) 微信小程序订阅消息参数示例：[{"mini_program_10":{"appId":"wxecb4693d2eef1ea7","appSecret":"6240870f4d91701640d769ba20120821","templateId":"JHUk6eE9T5TasdfCrQsk-Q","grantType":"client_credential","miniProgramState":"trial","page":"index?foo=bar"}}]
      */
-    public <T> T getAccount(Integer sendAccount, String apolloKey, String prefix, Class<T> clazz) {
+    public <T> T getSmsAccount(Integer sendAccount, String apolloKey, String prefix, Class<T> clazz) {
         String accountValues = config.getProperty(apolloKey, AustinConstant.APOLLO_DEFAULT_VALUE_JSON_ARRAY);
         JSONArray jsonArray = JSON.parseArray(accountValues);
         for (int i = 0; i < jsonArray.size(); i++) {
@@ -38,6 +43,27 @@ public class AccountUtils {
             T object = jsonObject.getObject(prefix + sendAccount, clazz);
             if (object != null) {
                 return object;
+            }
+        }
+        return null;
+    }
+
+    public <T> T getAccount(Integer sendAccount, String apolloKey, String prefix, Class<T> clazz) {
+        String accountValues = config.getProperty(sendAccount, apolloKey, AustinConstant.APOLLO_DEFAULT_VALUE_JSON_ARRAY);
+        if(enableMysql){
+            JSONObject jsonObject = JSONObject.parseObject(accountValues);
+            T object = jsonObject.toJavaObject(clazz);
+            if (object != null) {
+                return object;
+            }
+        }else {
+            JSONArray jsonArray = JSON.parseArray(accountValues);
+            for (int i = 0; i < jsonArray.size(); i++) {
+                JSONObject jsonObject = jsonArray.getJSONObject(i);
+                T object = jsonObject.getObject(prefix + sendAccount, clazz);
+                if (object != null) {
+                    return object;
+                }
             }
         }
         return null;

--- a/austin-support/src/main/java/com/java3y/austin/support/utils/AccountUtils.java
+++ b/austin-support/src/main/java/com/java3y/austin/support/utils/AccountUtils.java
@@ -34,6 +34,7 @@ public class AccountUtils {
      * (key:dingDingWorkNoticeAccount) 钉钉工作消息参数示例：[{"ding_ding_work_notice_10":{"appKey":"dingh6yyyyyyycrlbx","appSecret":"tQpvmkR863333yyyyyHP3QHyyyymy9Ao1yoL1oQX5NsdfsWHvWKbTu","agentId":"1523123123183622"}}]
      * (key:officialAccount) 微信服务号模板消息参数示例：[{"official_10":{"appId":"wxecb4693d2eef1ea7","secret":"624asdfsa1640d769ba20120821","templateId":"JHUk6eE9T5Ts7asdfsadfiKNDQsk-Q","url":"http://weixin.qq.com/download","miniProgramId":"xiaochengxuappid12345","path":"index?foo=bar"}}]
      * (key:miniProgramAccount) 微信小程序订阅消息参数示例：[{"mini_program_10":{"appId":"wxecb4693d2eef1ea7","appSecret":"6240870f4d91701640d769ba20120821","templateId":"JHUk6eE9T5TasdfCrQsk-Q","grantType":"client_credential","miniProgramState":"trial","page":"index?foo=bar"}}]
+     * (key:alipayMiniProgramAccount) 支付宝小程序订阅消息参数实例：[{"alipay_mini_program_10":{"privateKey":"MIIEvQIBADANB......","alipayPublicKey":"MIIBIjANBg...","appId":"2014********7148","userTemplateId":"MDI4YzIxMDE2M2I5YTQzYjUxNWE4MjA4NmU1MTIyYmM=","page":"page/component/index"}}]
      */
     public <T> T getSmsAccount(Integer sendAccount, String apolloKey, String prefix, Class<T> clazz) {
         String accountValues = config.getProperty(apolloKey, AustinConstant.APOLLO_DEFAULT_VALUE_JSON_ARRAY);

--- a/austin-web/src/main/resources/application.properties
+++ b/austin-web/src/main/resources/application.properties
@@ -1,14 +1,14 @@
-# TODO please replace 【must】 config value
-# TODO please replace 【must】 config value
-# TODO please replace 【must】 config value
+# TODO please replace \u3010must\u3011 config value
+# TODO please replace \u3010must\u3011 config value
+# TODO please replace \u3010must\u3011 config value
 
-# todo [database] ip/port/username/password 【must】
+# todo [database] ip/port/username/password \u3010must\u3011
 austin.database.ip=austin.mysql
 austin.database.port=5004
 austin.database.username=root
 austin.database.password=root123_A
 
-# todo [redis] ip/port/password【must】
+# todo [redis] ip/port/password\u3010must\u3011
 austin.redis.ip=austin.redis
 austin.redis.port=5003
 austin.redis.password=austin
@@ -16,28 +16,29 @@ austin.redis.password=austin
 # TODO  choose : kafka/eventBus/rocketMq/rabbitMq, default  eventBus
 austin.mq.pipeline=eventBus
 
-# todo [kafka] ip/port【optional】, if austin.mq.pipeline=kafka 【must】
+# todo [kafka] ip/port\u3010optional\u3011, if austin.mq.pipeline=kafka \u3010must\u3011
 austin.kafka.ip=austin.kafka
 austin.kafka.port=9092
 
-# todo [rocketMq] 【optional】, if austin.mq.pipeline=rocketMq【must】
+# todo [rocketMq] \u3010optional\u3011, if austin.mq.pipeline=rocketMq\u3010must\u3011
 austin.rocketmq.nameserver.ip=
 austin.rocketmq.nameserver.port=
 
-# todo [rabbitMq] 【optional】, if austin.mq.pipeline=rabbitMq【must】
+# todo [rabbitMq] \u3010optional\u3011, if austin.mq.pipeline=rabbitMq\u3010must\u3011
 austin.rabbitmq.ip=
 austin.rabbitmq.port=
 
-# todo [xxl-job] switch 【optional】, if austin.xxl.job.enabled=true 【must】
+# todo [xxl-job] switch \u3010optional\u3011, if austin.xxl.job.enabled=true \u3010must\u3011
 austin.xxl.job.enabled=false
 austin.xxl.job.ip=127.0.0.1
 austin.xxl.job.port=6767
 
-# todo choose: apollo/nacos switch 【optional】 ,if apollo and nacos both false, use local.properties
+# todo choose: mysql/apollo/nacos switch \u3010optional\u3011 ,if apollo and nacos both false, use local.properties
 austin.apollo.enabled=false
 austin.nacos.enabled=false
+austin.mysql.enable=false
 
-# todo [grayLog] ip 【optional】
+# todo [grayLog] ip \u3010optional\u3011
 austin.grayLog.ip=austin.graylog
 
 ##################### system properties #####################
@@ -71,20 +72,20 @@ austin.rocketmq.recall.consumer.group=unique-recall-consumer-group
 
 
 ##################### Rabbit properties #####################
-#RabbitMq所在服务器IP
+#RabbitMq\u6240\u5728\u670D\u52A1\u5668IP
 spring.rabbitmq.host=${austin.rabbitmq.ip}
-#连接端口号
+#\u8FDE\u63A5\u7AEF\u53E3\u53F7
 spring.rabbitmq.port=${austin.rabbitmq.port}
 
 server.port=8080
 spring.application.name=cl
-#用户名
+#\u7528\u6237\u540D
 spring.rabbitmq.username=root
-#用户密码
+#\u7528\u6237\u5BC6\u7801
 spring.rabbitmq.password=123456
-# 开启发送确认
+# \u5F00\u542F\u53D1\u9001\u786E\u8BA4
 spring.rabbitmq.publisher-confirm-type=correlated
-# 开启发送失败退回
+# \u5F00\u542F\u53D1\u9001\u5931\u8D25\u9000\u56DE
 spring.rabbitmq.publisher-returns=true
 spring.rabbitmq.virtual-host=/
 austin.rabbitmq.topic.name=austinRabbit

--- a/pom.xml
+++ b/pom.xml
@@ -196,6 +196,13 @@
                 <version>${weixin-java}</version>
             </dependency>
 
+            <!-- 支付宝sdk https://mvnrepository.com/artifact/com.alipay.sdk/alipay-sdk-java -->
+            <dependency>
+                <groupId>com.alipay.sdk</groupId>
+                <artifactId>alipay-sdk-java</artifactId>
+                <version>4.33.39.ALL</version>
+            </dependency>
+
             <!--阿里云 钉钉 SDK-->
             <dependency>
                 <groupId>com.aliyun</groupId>


### PR DESCRIPTION
application.properties中的中文转ascii码是因为git到的默认编码格式不是UTF-8而是ISO-8859-1
大多数的修改都是不需要的，只需要添加austin.mysql.enable=即可（false关闭此功能，true开启此功能）