### PR TITLE
使用 微信 稳定版 Access token, 避免 Austin 与 业务方使用同一 appId 时, 出现 token 互踢现象

### DIFF
--- a/austin-cron/src/main/java/com/java3y/austin/cron/xxl/config/XxlJobConfig.java
+++ b/austin-cron/src/main/java/com/java3y/austin/cron/xxl/config/XxlJobConfig.java
@@ -20,6 +20,8 @@ public class XxlJobConfig {
     private String adminAddresses;
     @Value("${xxl.job.executor.appname}")
     private String appName;
+    @Value("${xxl.job.executor.address}")
+    private String address;
     @Value("${xxl.job.executor.ip}")
     private String ip;
     @Value("${xxl.job.executor.port}")
@@ -37,6 +39,7 @@ public class XxlJobConfig {
         XxlJobSpringExecutor xxlJobSpringExecutor = new XxlJobSpringExecutor();
         xxlJobSpringExecutor.setAdminAddresses(adminAddresses);
         xxlJobSpringExecutor.setAppname(appName);
+        xxlJobSpringExecutor.setAddress(address);
         xxlJobSpringExecutor.setIp(ip);
         xxlJobSpringExecutor.setPort(port);
         xxlJobSpringExecutor.setAccessToken(accessToken);

--- a/austin-service-api/src/main/java/com/java3y/austin/service/api/domain/SendResponse.java
+++ b/austin-service-api/src/main/java/com/java3y/austin/service/api/domain/SendResponse.java
@@ -2,6 +2,7 @@ package com.java3y.austin.service.api.domain;
 
 import lombok.AllArgsConstructor;
 import lombok.Data;
+import lombok.NoArgsConstructor;
 import lombok.experimental.Accessors;
 
 
@@ -13,6 +14,7 @@ import lombok.experimental.Accessors;
 @Data
 @Accessors(chain = true)
 @AllArgsConstructor
+@NoArgsConstructor
 public class SendResponse {
     /**
      * 响应状态

--- a/austin-support/src/main/java/com/java3y/austin/support/utils/AccountUtils.java
+++ b/austin-support/src/main/java/com/java3y/austin/support/utils/AccountUtils.java
@@ -123,6 +123,7 @@ public class AccountUtils {
         config.setAppId(officialAccount.getAppId());
         config.setSecret(officialAccount.getSecret());
         config.setToken(officialAccount.getToken());
+        config.useStableAccessToken(true);
         wxMpService.setWxMpConfigStorage(config);
         return wxMpService;
     }
@@ -138,6 +139,7 @@ public class AccountUtils {
         WxMaRedisBetterConfigImpl config = new WxMaRedisBetterConfigImpl(redisTemplateWxRedisOps(), SendAccountConstant.MINI_PROGRAM_TOKEN_PREFIX);
         config.setAppid(miniProgramAccount.getAppId());
         config.setSecret(miniProgramAccount.getAppSecret());
+        config.useStableAccessToken(true);
         wxMaService.setWxMaConfig(config);
         return wxMaService;
     }

--- a/austin-web/src/main/resources/application.properties
+++ b/austin-web/src/main/resources/application.properties
@@ -68,6 +68,7 @@ xxl.job.admin.username=${austin.xxl.job.username:admin}
 xxl.job.admin.password=${austin.xxl.job.password:123456}
 xxl.job.executor.appname=${austin.xxl.job.executor.appname:austin}
 xxl.job.executor.jobHandlerName=${austin.xxl.job.executor.jobHandlerName:austinJob}
+xxl.job.executor.address=${austin.xxl.job.address:}
 xxl.job.executor.ip=
 xxl.job.executor.port=${austin.xxl.executor.port:6666}
 xxl.job.executor.logpath=logs/xxl

--- a/pom.xml
+++ b/pom.xml
@@ -38,7 +38,7 @@
         <maven.compiler.source>${target.java.version}</maven.compiler.source>
         <maven.compiler.target>${target.java.version}</maven.compiler.target>
         <log4j.version>2.17.1</log4j.version>
-        <weixin-java>4.3.0</weixin-java>
+        <weixin-java>4.5.3.B</weixin-java>
     </properties>
 
     <dependencyManagement>


### PR DESCRIPTION
[小程序 稳定版 调用凭据接口说明](https://developers.weixin.qq.com/miniprogram/dev/OpenApiDoc/mp-access-token/getStableAccessToken.html)

[公众号 稳定版 调用凭据接口说明](https://developers.weixin.qq.com/doc/offiaccount/Basic_Information/getStableAccessToken.html)