### PR TITLE
引入 freemaker 增强模板渲染能力, 支持渲染动态表单

### DIFF
--- a/austin-cron/src/main/java/com/java3y/austin/cron/pending/CrowdBatchTaskPending.java
+++ b/austin-cron/src/main/java/com/java3y/austin/cron/pending/CrowdBatchTaskPending.java
@@ -53,10 +53,10 @@ public class CrowdBatchTaskPending extends AbstractLazyPending<CrowdInfoVo> {
     public void doHandle(List<CrowdInfoVo> crowdInfoVos) {
 
         // 1. 如果参数相同，组装成同一个MessageParam发送
-        Map<Map<String, String>, String> paramMap = MapUtil.newHashMap();
+        Map<Map<String, Object>, String> paramMap = MapUtil.newHashMap();
         for (CrowdInfoVo crowdInfoVo : crowdInfoVos) {
             String receiver = crowdInfoVo.getReceiver();
-            Map<String, String> vars = crowdInfoVo.getParams();
+            Map<String, Object> vars = crowdInfoVo.getParams();
             if (Objects.isNull(paramMap.get(vars))) {
                 paramMap.put(vars, receiver);
             } else {
@@ -68,7 +68,7 @@ public class CrowdBatchTaskPending extends AbstractLazyPending<CrowdInfoVo> {
 
         // 2. 组装参数
         List<MessageParam> messageParams = Lists.newArrayList();
-        for (Map.Entry<Map<String, String>, String> entry : paramMap.entrySet()) {
+        for (Map.Entry<Map<String, Object>, String> entry : paramMap.entrySet()) {
             MessageParam messageParam = MessageParam.builder().receiver(entry.getValue())
                     .variables(entry.getKey()).build();
             messageParams.add(messageParam);

--- a/austin-cron/src/main/java/com/java3y/austin/cron/service/impl/TaskHandlerImpl.java
+++ b/austin-cron/src/main/java/com/java3y/austin/cron/service/impl/TaskHandlerImpl.java
@@ -57,7 +57,7 @@ public class TaskHandlerImpl implements TaskHandler {
             }
 
             // 3. 每一行处理交给LazyPending
-            HashMap<String, String> params = ReadFileUtils.getParamFromLine(row.getFieldMap());
+            HashMap<String, Object> params = ReadFileUtils.getParamFromLine(row.getFieldMap());
             CrowdInfoVo crowdInfoVo = CrowdInfoVo.builder().receiver(row.getFieldMap().get(ReadFileUtils.RECEIVER_KEY))
                     .params(params).messageTemplateId(messageTemplateId).build();
             crowdBatchTaskPending.pending(crowdInfoVo);

--- a/austin-cron/src/main/java/com/java3y/austin/cron/utils/ReadFileUtils.java
+++ b/austin-cron/src/main/java/com/java3y/austin/cron/utils/ReadFileUtils.java
@@ -69,8 +69,8 @@ public class ReadFileUtils {
      * @param fieldMap
      * @return
      */
-    public static HashMap<String, String> getParamFromLine(Map<String, String> fieldMap) {
-        HashMap<String, String> params = MapUtil.newHashMap();
+    public static HashMap<String, Object> getParamFromLine(Map<String, String> fieldMap) {
+        HashMap<String, Object> params = MapUtil.newHashMap();
         for (Map.Entry<String, String> entry : fieldMap.entrySet()) {
             if (!ReadFileUtils.RECEIVER_KEY.equals(entry.getKey())) {
                 params.put(entry.getKey(), entry.getValue());
@@ -101,7 +101,7 @@ public class ReadFileUtils {
             CsvRow headerInfo = data.getRow(0);
             for (int i = 1; i < data.getRowCount(); i++) {
                 CsvRow row = data.getRow(i);
-                Map<String, String> param = MapUtil.newHashMap();
+                Map<String, Object> param = MapUtil.newHashMap();
                 for (int j = 1; j < headerInfo.size(); j++) {
                     param.put(headerInfo.get(j), row.get(j));
                 }

--- a/austin-cron/src/main/java/com/java3y/austin/cron/vo/CrowdInfoVo.java
+++ b/austin-cron/src/main/java/com/java3y/austin/cron/vo/CrowdInfoVo.java
@@ -35,5 +35,5 @@ public class CrowdInfoVo implements Serializable {
     /**
      * 参数信息
      */
-    private Map<String, String> params;
+    private Map<String, Object> params;
 }

--- a/austin-cron/src/main/java/com/java3y/austin/cron/xxl/config/XxlJobConfig.java
+++ b/austin-cron/src/main/java/com/java3y/austin/cron/xxl/config/XxlJobConfig.java
@@ -20,6 +20,8 @@ public class XxlJobConfig {
     private String adminAddresses;
     @Value("${xxl.job.executor.appname}")
     private String appName;
+    @Value("${xxl.job.executor.address}")
+    private String address;
     @Value("${xxl.job.executor.ip}")
     private String ip;
     @Value("${xxl.job.executor.port}")
@@ -37,6 +39,7 @@ public class XxlJobConfig {
         XxlJobSpringExecutor xxlJobSpringExecutor = new XxlJobSpringExecutor();
         xxlJobSpringExecutor.setAdminAddresses(adminAddresses);
         xxlJobSpringExecutor.setAppname(appName);
+        xxlJobSpringExecutor.setAddress(address);
         xxlJobSpringExecutor.setIp(ip);
         xxlJobSpringExecutor.setPort(port);
         xxlJobSpringExecutor.setAccessToken(accessToken);

--- a/austin-service-api-impl/src/main/java/com/java3y/austin/service/api/impl/action/AssembleAction.java
+++ b/austin-service-api-impl/src/main/java/com/java3y/austin/service/api/impl/action/AssembleAction.java
@@ -108,7 +108,7 @@ public class AssembleAction implements BusinessProcess<SendTaskModel> {
         Class<? extends ContentModel> contentModelClass = ChannelType.getChanelModelClassByCode(sendChannel);
 
         // 得到模板的 msgContent 和 入参
-        Map<String, String> variables = messageParam.getVariables();
+        Map<String, Object> variables = messageParam.getVariables();
         JSONObject jsonObject = JSON.parseObject(messageTemplate.getMsgContent());
 
 

--- a/austin-service-api/src/main/java/com/java3y/austin/service/api/domain/MessageParam.java
+++ b/austin-service-api/src/main/java/com/java3y/austin/service/api/domain/MessageParam.java
@@ -33,11 +33,11 @@ public class MessageParam {
      * @Description: 消息内容中的可变部分(占位符替换)
      * 可选
      */
-    private Map<String, String> variables;
+    private Map<String, Object> variables;
 
     /**
      * @Description: 扩展参数
      * 可选
      */
-    private Map<String, String> extra;
+    private Map<String, Object> extra;
 }

--- a/austin-service-api/src/main/java/com/java3y/austin/service/api/domain/SendResponse.java
+++ b/austin-service-api/src/main/java/com/java3y/austin/service/api/domain/SendResponse.java
@@ -2,6 +2,7 @@ package com.java3y.austin.service.api.domain;
 
 import lombok.AllArgsConstructor;
 import lombok.Data;
+import lombok.NoArgsConstructor;
 import lombok.experimental.Accessors;
 
 
@@ -13,6 +14,7 @@ import lombok.experimental.Accessors;
 @Data
 @Accessors(chain = true)
 @AllArgsConstructor
+@NoArgsConstructor
 public class SendResponse {
     /**
      * 响应状态

--- a/austin-support/pom.xml
+++ b/austin-support/pom.xml
@@ -123,6 +123,11 @@
             <artifactId>hades-nacos-starter</artifactId>
         </dependency>
 
+        <dependency>
+            <groupId>org.freemarker</groupId>
+            <artifactId>freemarker</artifactId>
+        </dependency>
+
     </dependencies>
 
 </project>

--- a/austin-support/src/main/java/com/java3y/austin/support/utils/ContentHolderUtil.java
+++ b/austin-support/src/main/java/com/java3y/austin/support/utils/ContentHolderUtil.java
@@ -1,6 +1,10 @@
 package com.java3y.austin.support.utils;
 
-import org.apache.commons.lang3.StringUtils;
+import cn.hutool.core.util.ObjectUtil;
+import cn.hutool.core.util.StrUtil;
+import cn.hutool.extra.template.TemplateEngine;
+import cn.hutool.extra.template.TemplateUtil;
+import cn.hutool.json.JSONUtil;
 import org.springframework.util.PropertyPlaceholderHelper;
 
 import java.text.MessageFormat;
@@ -11,6 +15,7 @@ import java.util.Map;
  * 内容占位符 替换
  * <p>
  * austin占位符格式{$var}
+ * json 占位符 {$_JSON_var}
  */
 public class ContentHolderUtil {
 
@@ -20,22 +25,32 @@ public class ContentHolderUtil {
     private static final String PLACE_HOLDER_PREFIX = "{$";
 
     /**
+     * 模版引擎解析字段前缀
+     */
+    private static final String JSON_FLAG_PREFIX = "_JSON_";
+
+    /**
      * 占位符后缀
      */
     private static final String PLACE_HOLDER_SUFFIX = "}";
 
     private static final PropertyPlaceholderHelper PROPERTY_PLACEHOLDER_HELPER = new PropertyPlaceholderHelper(PLACE_HOLDER_PREFIX, PLACE_HOLDER_SUFFIX);
 
+    private static final TemplateEngine engine = TemplateUtil.createEngine();
 
-    public static String replacePlaceHolder(final String template, final Map<String, String> paramMap) {
-        return PROPERTY_PLACEHOLDER_HELPER.replacePlaceholders(template, new CustomPlaceholderResolver(template, paramMap));
+
+    public static String replacePlaceHolder(final String template, final Map<String, Object> paramMap) {
+        String result = PROPERTY_PLACEHOLDER_HELPER.replacePlaceholders(template, new CustomPlaceholderResolver(template, paramMap));
+        // 最后用模板引擎动态解析一次json字符串
+        result = engine.getTemplate(result).render(paramMap);
+        return result;
     }
 
     private static class CustomPlaceholderResolver implements PropertyPlaceholderHelper.PlaceholderResolver {
         private final String template;
-        private final Map<String, String> paramMap;
+        private final Map<String, Object> paramMap;
 
-        public CustomPlaceholderResolver(String template, Map<String, String> paramMap) {
+        public CustomPlaceholderResolver(String template, Map<String, Object> paramMap) {
             super();
             this.template = template;
             this.paramMap = paramMap;
@@ -43,12 +58,22 @@ public class ContentHolderUtil {
 
         @Override
         public String resolvePlaceholder(String placeholderName) {
-            String value = paramMap.get(placeholderName);
-            if (StringUtils.isEmpty(value)) {
+            Object value = paramMap.get(placeholderName);
+            if (ObjectUtil.isEmpty(value)) {
                 String errorStr = MessageFormat.format("template:{0} require param:{1},but not exist! paramMap:{2}", template, placeholderName, paramMap.toString());
                 throw new IllegalArgumentException(errorStr);
             }
-            return value;
+            // 如果遇到 Json, 则先跳过不处理, 到外部使用整体模板引擎渲染
+            if (StrUtil.startWith(placeholderName, JSON_FLAG_PREFIX)) {
+                // 如果值为 字符串, 则将其转换为 JSON 做字段解析
+                if (value instanceof String) {
+                    Object jsonValue = JSONUtil.parse(value);
+                    paramMap.put(placeholderName, jsonValue);
+                }
+                return placeholderName;
+            }
+            return StrUtil.toString(value);
+
         }
     }
 

--- a/austin-web/src/main/java/com/java3y/austin/web/controller/MessageTemplateController.java
+++ b/austin-web/src/main/java/com/java3y/austin/web/controller/MessageTemplateController.java
@@ -133,7 +133,7 @@ public class MessageTemplateController {
     @ApiOperation("/测试发送接口")
     public SendResponse test(@RequestBody MessageTemplateParam messageTemplateParam) {
 
-        Map<String, String> variables = JSON.parseObject(messageTemplateParam.getMsgContent(), Map.class);
+        Map<String, Object> variables = JSON.parseObject(messageTemplateParam.getMsgContent(), Map.class);
         MessageParam messageParam = MessageParam.builder().receiver(messageTemplateParam.getReceiver()).variables(variables).build();
         SendRequest sendRequest = SendRequest.builder().code(BusinessCode.COMMON_SEND.getCode()).messageTemplateId(messageTemplateParam.getId()).messageParam(messageParam).build();
         SendResponse response = sendService.send(sendRequest);

--- a/austin-web/src/main/resources/application.properties
+++ b/austin-web/src/main/resources/application.properties
@@ -68,6 +68,7 @@ xxl.job.admin.username=${austin.xxl.job.username:admin}
 xxl.job.admin.password=${austin.xxl.job.password:123456}
 xxl.job.executor.appname=${austin.xxl.job.executor.appname:austin}
 xxl.job.executor.jobHandlerName=${austin.xxl.job.executor.jobHandlerName:austinJob}
+xxl.job.executor.address=${austin.xxl.job.address:}
 xxl.job.executor.ip=
 xxl.job.executor.port=${austin.xxl.executor.port:6666}
 xxl.job.executor.logpath=logs/xxl

--- a/pom.xml
+++ b/pom.xml
@@ -230,6 +230,14 @@
             <!--                <artifactId>hades-apollo-starter</artifactId>-->
             <!--                <version>1.0.4</version>-->
             <!--            </dependency>-->
+
+
+            <dependency>
+                <groupId>org.freemarker</groupId>
+                <artifactId>freemarker</artifactId>
+                <version>2.3.32</version>
+            </dependency>
+
         </dependencies>
     </dependencyManagement>
 


### PR DESCRIPTION
@ZhongFuCheng3y 
之前内部分享的时候, 有提到过模板渲染支持表格的参数动态渲染, 满足一些邮件表格数据的发送
看了下Austin 代码的设计, 我这边做了 基于 Freemaker 的模板引擎渲染, 对现有的设计兼容还算不错

使用方法
将模板参数定义为 {$_JSON_XXX}, 在组装的时候, 会先将其转化为 _JSON_XXX, 最终再用模板引擎渲染一遍

如果觉得还 ok, 可能还需要更新下 项目的 README 说明, 以便体现此特性.