### PR TITLE
 修复SSRF漏洞

### DIFF
--- a/austin-common/src/main/java/com/java3y/austin/common/constant/CommonConstant.java
+++ b/austin-common/src/main/java/com/java3y/austin/common/constant/CommonConstant.java
@@ -45,6 +45,12 @@ public class CommonConstant {
     public static final String CONTENT_TYPE_FORM_URL_ENCODE = "application/x-www-form-urlencoded;charset=utf-8;";
     public static final String CONTENT_TYPE_MULTIPART_FORM_DATA = "multipart/form-data";
     /**
+     * 协议
+     */
+    public static final String HTTP = "http";
+    public static final String HTTPS = "https";
+    public static final String OSS = "oss";
+    /**
      * HTTP 请求方法
      */
     public static final String REQUEST_METHOD_GET = "GET";

--- a/austin-support/src/main/java/com/java3y/austin/support/utils/AustinFileUtils.java
+++ b/austin-support/src/main/java/com/java3y/austin/support/utils/AustinFileUtils.java
@@ -2,6 +2,7 @@ package com.java3y.austin.support.utils;
 
 import cn.hutool.core.io.IoUtil;
 import com.google.common.base.Throwables;
+import com.java3y.austin.common.constant.CommonConstant;
 import lombok.extern.slf4j.Slf4j;
 
 import java.io.File;
@@ -38,6 +39,15 @@ public class AustinFileUtils {
         FileOutputStream fileOutputStream = null;
         try {
             URL url = new URL(remoteUrl);
+            String protocol = url.getProtocol();
+            // 防止SSRF攻击
+            if (!CommonConstant.HTTP.equalsIgnoreCase(protocol)
+                    && !CommonConstant.HTTPS.equalsIgnoreCase(protocol)
+                    && !CommonConstant.OSS.equalsIgnoreCase(protocol)) {
+                log.error("AustinFileUtils#getRemoteUrl2File fail:{}, remoteUrl:{}",
+                        "The remoteUrl is invalid, it can only be of the types http, https, and oss.", remoteUrl);
+                return null;
+            }
             File file = new File(path, url.getPath());
             inputStream = url.openStream();
             if (!file.exists()) {


### PR DESCRIPTION
一、根据#56 Issues描述，测试发现，确实有SSRF攻击风险，通过file://协议能直接把服务器内任何文件，当做附件发送出去。
二、已指定协议白名单，禁止使用file://、ftp://等协议。
三、建议：更合理的方式，应该是做IP白名单，并限制文件大小（但限制太多，反而让使用与开发难受，暂不展开）。

望3y大佬通过PR