### PR TITLE
fix: 修复敏感词初始化问题

### DIFF
--- a/austin-handler/src/main/java/com/java3y/austin/handler/config/SensitiveWordsConfig.java
+++ b/austin-handler/src/main/java/com/java3y/austin/handler/config/SensitiveWordsConfig.java
@@ -124,7 +124,7 @@ public class SensitiveWordsConfig {
             try {
                 TimeUnit.SECONDS.sleep(UPDATE_TIME_SECONDS);
                 log.debug("SensitiveWordConfig#startScheduledUpdate start update...");
-                loadSensitiveWords();
+                loadSensWords();
                 storeSensWords();
             } catch (InterruptedException e) {
                 log.error("SensitiveWordConfig#startScheduledUpdate interrupted: {}", e.getMessage());


### PR DESCRIPTION
一、根据#71 Issues描述，初始化敏感词时，调用方法有误，确有该问题，提单改正。